### PR TITLE
Fixed bug with offsets in midi parsing function

### DIFF
--- a/onsets_and_frames/midi.py
+++ b/onsets_and_frames/midi.py
@@ -42,7 +42,8 @@ def parse_midi(path):
 
         if offset['sustain'] and offset is not events[-1]:
             # if the sustain pedal is active at offset, find when the sustain ends
-            offset = next(n for n in events[offset['index'] + 1:] if n['type'] == 'sustain_off' or n is events[-1])
+            offset = next(n for n in events[offset['index'] + 1:]
+                          if n['type'] == 'sustain_off' or n['note'] == onset['note'] or n is events[-1])
 
         note = (onset['time'], offset['time'], onset['note'], onset['velocity'])
         notes.append(note)


### PR DESCRIPTION
Offsets were not properly set for multiple notes of the same pitch occurring while sustain was active.

If sustain was active during the note offset, the true offset was set to the time when the sustain was lifted.

However, this did not consider the case where the note was activated again before the sustain pedal was lifted.